### PR TITLE
Multiple targets in lint runner

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,7 @@ test {
 }
 
 dependencies {
+    implementation group: 'commons-io', name: 'commons-io', version: '2.6'
     implementation group: 'org.json', name: 'json', version: '20180813'
     implementation group: 'com.j2html', name: 'j2html', version: '1.4.0'
 

--- a/src/test/java/com/zachary_moore/runner/LintRunnerShould.java
+++ b/src/test/java/com/zachary_moore/runner/LintRunnerShould.java
@@ -74,4 +74,19 @@ public class LintRunnerShould {
         lintRunner.lint();
         assert(lintRunner.analyzeLintAndGiveExitCode() == 0);
     }
+
+    @Test
+    public void lintRunnerShouldTakeMultipleFiles() throws Exception {
+        LintRule lintRule = builder.setLevel(LintLevel.ERROR).build();
+        this.lintRegister.register(lintRule);
+        LintRunner lintRunner =
+                new LintRunner(
+                        this.lintRegister,
+                        "./src/test/resources/test-2.json",
+                        "./src/test/resources/test-file.pdsc");
+        Map<LintRule, Map<JSONFile, List<String>>> lintOutput = lintRunner.lint();
+
+        assert(lintRunner.analyzeLintAndGiveExitCode() == 1);
+        assert(lintOutput.get(lintRule).size() == 2);
+    }
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ✔] Tests for the changes have been added (for bug fixes / features)
- [ ✔] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
Only one path can be provided to the LintRunner for linting. This could either be the path to a single file or a directory. But to lint multiple files/directory with the same rules, multiple instances of LintRunner would need to be created.


* **What is the new behavior (if this is a feature change)?**
Multiple files or folders (or a combination) can be linted with a common set of rules by a single LintRunner.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Completely backward compatible


* **Other information**:
