### PR TITLE
Revert "Make constructors of JSONArray, JSONObject and WrappedPrimitive objec…"

### DIFF
--- a/src/main/java/com/zachary_moore/objects/JSONArray.java
+++ b/src/main/java/com/zachary_moore/objects/JSONArray.java
@@ -14,7 +14,7 @@ public class JSONArray extends org.json.JSONArray implements WrappedObject {
 
     private List<Object> contents;
 
-    public JSONArray(String originatingKey,
+    JSONArray(String originatingKey,
               WrappedObject parentObject,
               org.json.JSONArray clone) {
         super(clone != null ? clone.toList() : null);

--- a/src/main/java/com/zachary_moore/objects/JSONObject.java
+++ b/src/main/java/com/zachary_moore/objects/JSONObject.java
@@ -12,7 +12,7 @@ public class JSONObject extends org.json.JSONObject implements WrappedObject {
 
     private final org.json.JSONObject clonedObject;
 
-    public JSONObject(String originatingKey,
+    JSONObject(String originatingKey,
                WrappedObject parentObject,
                org.json.JSONObject clone) {
         super(clone != null ? clone.toMap() : null);

--- a/src/main/java/com/zachary_moore/objects/WrappedPrimitive.java
+++ b/src/main/java/com/zachary_moore/objects/WrappedPrimitive.java
@@ -10,7 +10,7 @@ public class WrappedPrimitive<T> implements WrappedObject {
     private final WrappedObject parentObject;
     private final T value;
 
-    public WrappedPrimitive(String originatingKey,
+    WrappedPrimitive(String originatingKey,
                      WrappedObject parentObject,
                      T originalObject) {
         if (originatingKey == null && parentObject != null) {


### PR DESCRIPTION
Reverts zsmoore/JSONCustomLintr#43

Revert public constructors until clear reasons for needing them is displayed.

WrappedObjects are only instantiated by the internal parser and don't have value by being instantiated freely.