### PR TITLE
Reverting toArray call, it is valid to pass in pre-alloc size

### DIFF
--- a/src/main/java/com/zachary_moore/runner/LintRunner.java
+++ b/src/main/java/com/zachary_moore/runner/LintRunner.java
@@ -72,7 +72,7 @@ public class LintRunner {
         for (LintRule lintRule : lintRegister.getLintRules()) {
             try {
                 if (lintRule.getLevel() != LintLevel.IGNORE) {
-                    Map<JSONFile, List<String>> lintReports = lintRule.lint(filesToLint.toArray(new JSONFile[0]));
+                    Map<JSONFile, List<String>> lintReports = lintRule.lint(filesToLint.toArray(new JSONFile[filesToLint.size()]));
                     if (lintReports.size() != 0) {
                         lintOutput.put(lintRule, lintReports);
                     }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [ N/A] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Reverts a change in pr #40.  As per javadocs

https://docs.oracle.com/javase/7/docs/api/java/util/Set.html#toArray(T[])

and ` If the set fits in the specified array, it is returned therein. Otherwise, a new array is allocated with the runtime type of the specified array and the size of this set.`

Passing size is a valid thing to do.

* **What is the current behavior?** (You can also link to an open issue here)
Current behavior is the same as 

`(JsonFile[]) filesToLint.toArray()` 

* **What is the new behavior (if this is a feature change)?**
Array is optimized with same size as needed and no longer makes an unnecessary array of size 0 on each toArray call.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None.


* **Other information**:
