### PR TITLE
Make constructors of internal objects protected

### DIFF
--- a/src/main/java/com/zachary_moore/objects/JSONArray.java
+++ b/src/main/java/com/zachary_moore/objects/JSONArray.java
@@ -14,9 +14,9 @@ public class JSONArray extends org.json.JSONArray implements WrappedObject {
 
     private List<Object> contents;
 
-    public JSONArray(String originatingKey,
-              WrappedObject parentObject,
-              org.json.JSONArray clone) {
+    protected JSONArray(String originatingKey,
+                        WrappedObject parentObject,
+                        org.json.JSONArray clone) {
         super(clone != null ? clone.toList() : null);
         if (originatingKey == null && parentObject != null) {
             this.originatingKey = parentObject.getOriginatingKey();

--- a/src/main/java/com/zachary_moore/objects/JSONObject.java
+++ b/src/main/java/com/zachary_moore/objects/JSONObject.java
@@ -12,9 +12,9 @@ public class JSONObject extends org.json.JSONObject implements WrappedObject {
 
     private final org.json.JSONObject clonedObject;
 
-    public JSONObject(String originatingKey,
-               WrappedObject parentObject,
-               org.json.JSONObject clone) {
+    protected JSONObject(String originatingKey,
+                         WrappedObject parentObject,
+                         org.json.JSONObject clone) {
         super(clone != null ? clone.toMap() : null);
         if (originatingKey == null && parentObject != null) {
             this.originatingKey = parentObject.getOriginatingKey();

--- a/src/main/java/com/zachary_moore/objects/WrappedPrimitive.java
+++ b/src/main/java/com/zachary_moore/objects/WrappedPrimitive.java
@@ -10,9 +10,9 @@ public class WrappedPrimitive<T> implements WrappedObject {
     private final WrappedObject parentObject;
     private final T value;
 
-    public WrappedPrimitive(String originatingKey,
-                     WrappedObject parentObject,
-                     T originalObject) {
+    protected WrappedPrimitive(String originatingKey,
+                               WrappedObject parentObject,
+                               T originalObject) {
         if (originatingKey == null && parentObject != null) {
             this.originatingKey = parentObject.getOriginatingKey();
         } else {


### PR DESCRIPTION

#46 

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature enhancement


* **What is the current behavior?** (You can also link to an open issue here)
Constructors are public and anyone can instantiate these objects


* **What is the new behavior (if this is a feature change)?**
Only sub classes can instantiate the constructor to allow for import wrapping.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
This breaks anyone using a non-released version and using public constructors.
