### PR TITLE
Adding ability to have lint rules for JSONFile, exposing extension in…

### DIFF
--- a/src/main/java/com/zachary_moore/filters/BaseFilter.java
+++ b/src/main/java/com/zachary_moore/filters/BaseFilter.java
@@ -23,7 +23,7 @@ class BaseFilter {
      * @return {@link ArrayList<T>} of given class type from JSONFile
      */
     <T> List<T> getAllOfType(JSONFile file, Class<T> clazz) {
-        Object baseObject = file.getObject();
+        Object baseObject = file.getChild();
         if (baseObject instanceof JSONObject) {
             return accumulateType((JSONObject) baseObject, clazz);
         } else if (baseObject instanceof JSONArray){
@@ -42,7 +42,7 @@ class BaseFilter {
      */
     <T> List<WrappedPrimitive<T>> getAllOfWrappedType(JSONFile file, Class<T> clazz) {
         ArrayList<WrappedPrimitive<T>> wrappedTypeList = new ArrayList<>();
-        Object baseObject = file.getObject();
+        Object baseObject = file.getChild();
         if (baseObject instanceof JSONObject) {
             wrappedTypeList.addAll(accumulateWrappedTypeFromEntrySet(((JSONObject) baseObject).toMap().entrySet(), clazz));
         } else if (baseObject instanceof JSONArray) {

--- a/src/main/java/com/zachary_moore/filters/FilterMapper.java
+++ b/src/main/java/com/zachary_moore/filters/FilterMapper.java
@@ -7,6 +7,7 @@ import com.zachary_moore.objects.JSONObject;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.List;
 
 public class FilterMapper {
@@ -50,6 +51,8 @@ public class FilterMapper {
             return filters.filterToObjects(jsonFile);
         } else if (lintImplementation.getClazz() == JSONArray.class) {
             return filters.filterToArrays(jsonFile);
+        } else if (lintImplementation.getClazz() == JSONFile.class) {
+            return Collections.singletonList(jsonFile);
         } else {
             return null;
         }

--- a/src/main/java/com/zachary_moore/objects/JSONFile.java
+++ b/src/main/java/com/zachary_moore/objects/JSONFile.java
@@ -1,5 +1,6 @@
 package com.zachary_moore.objects;
 
+import org.apache.commons.io.FilenameUtils;
 import org.json.JSONException;
 import org.json.JSONTokener;
 
@@ -8,21 +9,31 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 
-public class JSONFile {
+public class JSONFile implements WrappedObject {
 
-    private org.json.JSONObject jsonObject;
-    private org.json.JSONArray jsonArray;
+    private JSONObject wrappedJsonObject;
+    private JSONArray wrappedJsonArray;
     private String filePath;
+    private String fileExtension;
 
     public JSONFile(File file) throws IOException {
         filePath = file.getCanonicalPath();
+        fileExtension = FilenameUtils.getExtension(filePath);
+        initializeWrappedObjects(file);
+    }
+
+    private void initializeWrappedObjects(File file) throws IOException {
         BufferedReader bufferedReader = new BufferedReader(new FileReader(file));
         JSONTokener jsonTokener = new JSONTokener(bufferedReader);
         try {
-            jsonObject = new org.json.JSONObject(jsonTokener);
+            this.wrappedJsonObject = new JSONObject(null,
+                    this,
+                    new org.json.JSONObject(jsonTokener));
         } catch (JSONException e) {
             jsonTokener.back();
-            jsonArray = new org.json.JSONArray(jsonTokener);
+            this.wrappedJsonArray = new JSONArray(null,
+                    this,
+                    new org.json.JSONArray(jsonTokener));
         }
         bufferedReader.close();
     }
@@ -30,18 +41,34 @@ public class JSONFile {
     /**
      * @return either {@link JSONObject} or {@link JSONArray} based on input file to constructor
      */
-    public Object getObject() {
-        if (jsonObject != null) {
-            return new JSONObject(null, null, jsonObject);
-        } else if (jsonArray != null) {
-            return new JSONArray(null, null, jsonArray);
-        } else {
-            throw new RuntimeException("Could not parse either a JSONArray or JSONObject from file");
-        }
+    public WrappedObject getChild() {
+        return wrappedJsonObject != null ? wrappedJsonObject : wrappedJsonArray;
+    }
+
+    @Override
+    public String getOriginatingKey() {
+        return null;
+    }
+
+    @Override
+    public WrappedObject getParentObject() {
+        return null;
+    }
+
+    @Override
+    public void parseAndReplaceWithWrappers() { }
+
+    @Override
+    public boolean isPrimitive() {
+        return false;
     }
 
     public String getFilePath() {
         return filePath;
+    }
+
+    public String getFileExtension() {
+        return fileExtension;
     }
 
     @Override

--- a/src/test/java/com/zachary_moore/objects/JSONFileShould.java
+++ b/src/test/java/com/zachary_moore/objects/JSONFileShould.java
@@ -3,29 +3,56 @@ package com.zachary_moore.objects;
 
 import java.io.File;
 import java.io.IOException;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 public class JSONFileShould {
 
+    private File jsonObjectFile;
+    private File jsonArrayFile;
+
+    public JSONFileShould() {
+        jsonObjectFile = new File(getClass()
+            .getClassLoader()
+            .getResource("test-2.json")
+            .getFile());
+        jsonArrayFile = new File(getClass()
+            .getClassLoader()
+            .getResource("array-file.json")
+            .getFile());
+    }
+
     @Test
     public void JSONFileGivesJSONArray() throws IOException {
-        JSONFile jsonFile = new JSONFile(
-                new File(getClass()
-                         .getClassLoader()
-                         .getResource("array-file.json")
-                         .getFile()));
-        assert(jsonFile.getObject() instanceof JSONArray);
-        assert(((JSONArray)jsonFile.getObject()).length() == 3);
+        JSONFile jsonFile = new JSONFile(jsonArrayFile);
+        assert(jsonFile.getChild() instanceof JSONArray);
+        assert(((JSONArray)jsonFile.getChild()).length() == 3);
     }
 
     @Test
     public void JSONFileGivesJSONObject() throws IOException {
-        JSONFile jsonFile = new JSONFile(
-                new File(getClass()
-                        .getClassLoader()
-                        .getResource("test-2.json")
-                        .getFile()));
-        assert(jsonFile.getObject() instanceof JSONObject);
+        JSONFile jsonFile = new JSONFile(jsonObjectFile);
+        assert(jsonFile.getChild() instanceof JSONObject);
+    }
+
+    @Test
+    public void JSONFileGivesFilePath() throws IOException {
+        JSONFile jsonFile = new JSONFile(jsonObjectFile);
+        assert(jsonFile.getFilePath().equals(jsonObjectFile.getAbsolutePath()));
+    }
+
+    @Test
+    public void JSONFileGivesFileExtension() throws IOException {
+        JSONFile jsonFile = new JSONFile(jsonObjectFile);
+        assert(jsonFile.getFileExtension().equals("json"));
+    }
+
+    @Test
+    public void JSONFileChildShouldHaveParent() throws IOException {
+        JSONFile jsonFile = new JSONFile(jsonObjectFile);
+        assertNotNull(jsonFile.getChild().getParentObject());
     }
 }

--- a/src/test/java/com/zachary_moore/runner/LintSituationsShould.java
+++ b/src/test/java/com/zachary_moore/runner/LintSituationsShould.java
@@ -1,0 +1,120 @@
+package com.zachary_moore.runner;
+
+import com.zachary_moore.lint.LintImplementation;
+import com.zachary_moore.lint.LintLevel;
+import com.zachary_moore.lint.LintRegister;
+import com.zachary_moore.lint.LintRule;
+import com.zachary_moore.objects.JSONFile;
+import com.zachary_moore.objects.JSONObject;
+import com.zachary_moore.objects.WrappedObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+
+public class LintSituationsShould {
+
+    private LintRule.Builder builder;
+    private LintRegister lintRegister;
+
+    @BeforeEach
+    public void setUp() {
+      this.builder = new LintRule.Builder().setIssueId("");
+      this.lintRegister = new LintRegister();
+    }
+
+    @Test
+    public void shouldReportFilePathViolation() throws Exception {
+        LintRule lintRule = this.builder.setImplementation(new LintImplementation<JSONFile>() {
+            @Override
+            public Class<?> getClazz() {
+                return JSONFile.class;
+            }
+
+            @Override
+            public boolean shouldReport(JSONFile jsonFile) {
+                File file = new File(jsonFile.getFilePath());
+                return file.getParentFile().getName().contains("resources");
+            }
+
+            @Override
+            public String report(JSONFile jsonFile) {
+                return "File can not have parent directory resources";
+            }
+        }).setLevel(LintLevel.ERROR)
+          .build();
+        this.lintRegister.register(lintRule);
+        LintRunner lintRunner =
+                new LintRunner(this.lintRegister,
+                               "./src/test/resources/test-2.json",
+                               "./src/test/resources/test-file.pdsc");
+
+        Map<LintRule, Map<JSONFile, List<String>>> lintOutput = lintRunner.lint();
+        assert(lintRunner.analyzeLintAndGiveExitCode() == 1);
+        assert(lintOutput.get(lintRule).size() == 2);
+    }
+
+    @Test
+    public void jsonFileShouldHaveChildObject() throws Exception {
+        LintRule lintRule = this.builder.setImplementation(new LintImplementation<JSONFile>() {
+            @Override
+            public Class<?> getClazz() {
+                return JSONFile.class;
+            }
+
+            @Override
+            public boolean shouldReport(JSONFile jsonFile) {
+                WrappedObject child = jsonFile.getChild();
+                return child instanceof JSONObject;
+            }
+
+            @Override
+            public String report(JSONFile jsonFile) {
+                return "Expect a JSONArray as child";
+            }
+        }).setLevel(LintLevel.ERROR)
+          .build();
+        this.lintRegister.register(lintRule);
+        LintRunner lintRunner =
+                new LintRunner(this.lintRegister,
+                        "./src/test/resources/test-2.json",
+                        "./src/test/resources/test-file.pdsc");
+
+        Map<LintRule, Map<JSONFile, List<String>>> lintOutput = lintRunner.lint();
+        assert(lintRunner.analyzeLintAndGiveExitCode() == 1);
+        assert(lintOutput.get(lintRule).size() == 2);
+    }
+
+    @Test
+    public void jsonFileShouldDetectFileExtension() throws Exception {
+        LintRule lintRule = this.builder.setImplementation(new LintImplementation<JSONFile>() {
+            @Override
+            public Class<?> getClazz() {
+                return JSONFile.class;
+            }
+
+            @Override
+            public boolean shouldReport(JSONFile jsonFile) {
+                return jsonFile.getFileExtension().equals("pdsc");
+            }
+
+            @Override
+            public String report(JSONFile jsonFile) {
+                return "Expect a JSONArray as child";
+            }
+        }).setLevel(LintLevel.ERROR)
+          .build();
+        this.lintRegister.register(lintRule);
+        LintRunner lintRunner =
+                new LintRunner(this.lintRegister,
+                        "./src/test/resources/test-2.json",
+                        "./src/test/resources/test-file.pdsc");
+
+        Map<LintRule, Map<JSONFile, List<String>>> lintOutput = lintRunner.lint();
+        assert(lintRunner.analyzeLintAndGiveExitCode() == 1);
+        assert(lintOutput.get(lintRule).size() == 1);
+    }
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [YES ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

#28 

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Exposes JSONFile to the linter, allows users to make lint rules for the file.
Adds file extension to the JSONFile


* **What is the current behavior?** (You can also link to an open issue here)
You can't lint on JSONFile


* **What is the new behavior (if this is a feature change)?**
Lint rules for JSONFile can be created.
File extension exposed

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
getObject is no longer usable but should not have been used outside of library.


* **Other information**:
